### PR TITLE
Small fixes

### DIFF
--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -143,7 +143,9 @@ span.tooltipeded {
 }
 
 #chat .count:before,
-#chat .user-mode:before {
+#chat .user-mode:before,
+#chat button.mentions,
+#chat form.message-search button {
     color: #{{overlay0.hex}};
 }
 

--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -223,7 +223,7 @@ body {
 }
 
 .context-menu-item,
-.textcomplete-item a {
+.textcomplete-item {
     color: var(--body-color);
 }
 

--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -182,7 +182,7 @@ span.tooltipeded {
 #chat .msg[data-type="quit"] .content,
 #chat .msg[data-type="topic"] .content,
 #chat .msg[data-type="topic_set_by"] .content {
-    color: #{{surface1.hex}};
+    color: #{{overlay0.hex}};
 }
 #context-menu,
 .textcomplete-menu {

--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -137,6 +137,11 @@ span.tooltipeded {
     color: #{{text.hex}};
 }
 
+.channel-list-item.not-connected,
+.channel-list-item.parted-channel {
+    color: #{{maroon.hex}};
+}
+
 #chat .count:before,
 #chat .user-mode:before {
     color: #{{overlay0.hex}};
@@ -184,6 +189,12 @@ span.tooltipeded {
 #chat .msg[data-type="topic_set_by"] .content {
     color: #{{overlay0.hex}};
 }
+
+#chat .msg[data-type="error"] .content,
+#chat .msg[data-type="error"] .from {
+    color: #{{maroon.hex}};
+}
+
 #context-menu,
 .textcomplete-menu {
     background-color: var(--window-bg-color);

--- a/templates/theme.tera
+++ b/templates/theme.tera
@@ -380,11 +380,11 @@ form.message-search input::placeholder {
     color: #{{surface2.hex}};
 }
 
-#chat .channel .msg.highlight .time {
+#chat .chat-view[data-type=channel] .msg.highlight .time {
     color: var(--body-color);
 }
 
-#chat .channel .highlight .toggle-content {
+#chat .chat-view[data-type=channel] .highlight .toggle-content {
     background-color: #{{overlay0.hex}};
 }
 

--- a/themes/catppuccin-frappe/theme.css
+++ b/themes/catppuccin-frappe/theme.css
@@ -130,8 +130,15 @@ span.tooltipeded {
     color: #c6d0f5;
 }
 
+.channel-list-item.not-connected,
+.channel-list-item.parted-channel {
+    color: #ea999c;
+}
+
 #chat .count:before,
-#chat .user-mode:before {
+#chat .user-mode:before,
+#chat button.mentions,
+#chat form.message-search button {
     color: #737994;
 }
 
@@ -175,8 +182,14 @@ span.tooltipeded {
 #chat .msg[data-type="quit"] .content,
 #chat .msg[data-type="topic"] .content,
 #chat .msg[data-type="topic_set_by"] .content {
-    color: #51576d;
+    color: #737994;
 }
+
+#chat .msg[data-type="error"] .content,
+#chat .msg[data-type="error"] .from {
+    color: #ea999c;
+}
+
 #context-menu,
 .textcomplete-menu {
     background-color: var(--window-bg-color);
@@ -216,7 +229,7 @@ body {
 }
 
 .context-menu-item,
-.textcomplete-item a {
+.textcomplete-item {
     color: var(--body-color);
 }
 
@@ -373,11 +386,11 @@ form.message-search input::placeholder {
     color: #626880;
 }
 
-#chat .channel .msg.highlight .time {
+#chat .chat-view[data-type=channel] .msg.highlight .time {
     color: var(--body-color);
 }
 
-#chat .channel .highlight .toggle-content {
+#chat .chat-view[data-type=channel] .highlight .toggle-content {
     background-color: #737994;
 }
 

--- a/themes/catppuccin-latte/theme.css
+++ b/themes/catppuccin-latte/theme.css
@@ -130,8 +130,15 @@ span.tooltipeded {
     color: #4c4f69;
 }
 
+.channel-list-item.not-connected,
+.channel-list-item.parted-channel {
+    color: #e64553;
+}
+
 #chat .count:before,
-#chat .user-mode:before {
+#chat .user-mode:before,
+#chat button.mentions,
+#chat form.message-search button {
     color: #9ca0b0;
 }
 
@@ -175,8 +182,14 @@ span.tooltipeded {
 #chat .msg[data-type="quit"] .content,
 #chat .msg[data-type="topic"] .content,
 #chat .msg[data-type="topic_set_by"] .content {
-    color: #bcc0cc;
+    color: #9ca0b0;
 }
+
+#chat .msg[data-type="error"] .content,
+#chat .msg[data-type="error"] .from {
+    color: #e64553;
+}
+
 #context-menu,
 .textcomplete-menu {
     background-color: var(--window-bg-color);
@@ -216,7 +229,7 @@ body {
 }
 
 .context-menu-item,
-.textcomplete-item a {
+.textcomplete-item {
     color: var(--body-color);
 }
 
@@ -373,11 +386,11 @@ form.message-search input::placeholder {
     color: #acb0be;
 }
 
-#chat .channel .msg.highlight .time {
+#chat .chat-view[data-type=channel] .msg.highlight .time {
     color: var(--body-color);
 }
 
-#chat .channel .highlight .toggle-content {
+#chat .chat-view[data-type=channel] .highlight .toggle-content {
     background-color: #9ca0b0;
 }
 

--- a/themes/catppuccin-macchiato/theme.css
+++ b/themes/catppuccin-macchiato/theme.css
@@ -130,8 +130,15 @@ span.tooltipeded {
     color: #cad3f5;
 }
 
+.channel-list-item.not-connected,
+.channel-list-item.parted-channel {
+    color: #ee99a0;
+}
+
 #chat .count:before,
-#chat .user-mode:before {
+#chat .user-mode:before,
+#chat button.mentions,
+#chat form.message-search button {
     color: #6e738d;
 }
 
@@ -175,8 +182,14 @@ span.tooltipeded {
 #chat .msg[data-type="quit"] .content,
 #chat .msg[data-type="topic"] .content,
 #chat .msg[data-type="topic_set_by"] .content {
-    color: #494d64;
+    color: #6e738d;
 }
+
+#chat .msg[data-type="error"] .content,
+#chat .msg[data-type="error"] .from {
+    color: #ee99a0;
+}
+
 #context-menu,
 .textcomplete-menu {
     background-color: var(--window-bg-color);
@@ -216,7 +229,7 @@ body {
 }
 
 .context-menu-item,
-.textcomplete-item a {
+.textcomplete-item {
     color: var(--body-color);
 }
 
@@ -373,11 +386,11 @@ form.message-search input::placeholder {
     color: #5b6078;
 }
 
-#chat .channel .msg.highlight .time {
+#chat .chat-view[data-type=channel] .msg.highlight .time {
     color: var(--body-color);
 }
 
-#chat .channel .highlight .toggle-content {
+#chat .chat-view[data-type=channel] .highlight .toggle-content {
     background-color: #6e738d;
 }
 

--- a/themes/catppuccin-mocha/theme.css
+++ b/themes/catppuccin-mocha/theme.css
@@ -130,8 +130,15 @@ span.tooltipeded {
     color: #cdd6f4;
 }
 
+.channel-list-item.not-connected,
+.channel-list-item.parted-channel {
+    color: #eba0ac;
+}
+
 #chat .count:before,
-#chat .user-mode:before {
+#chat .user-mode:before,
+#chat button.mentions,
+#chat form.message-search button {
     color: #6c7086;
 }
 
@@ -175,8 +182,14 @@ span.tooltipeded {
 #chat .msg[data-type="quit"] .content,
 #chat .msg[data-type="topic"] .content,
 #chat .msg[data-type="topic_set_by"] .content {
-    color: #45475a;
+    color: #6c7086;
 }
+
+#chat .msg[data-type="error"] .content,
+#chat .msg[data-type="error"] .from {
+    color: #eba0ac;
+}
+
 #context-menu,
 .textcomplete-menu {
     background-color: var(--window-bg-color);
@@ -216,7 +229,7 @@ body {
 }
 
 .context-menu-item,
-.textcomplete-item a {
+.textcomplete-item {
     color: var(--body-color);
 }
 
@@ -373,11 +386,11 @@ form.message-search input::placeholder {
     color: #585b70;
 }
 
-#chat .channel .msg.highlight .time {
+#chat .chat-view[data-type=channel] .msg.highlight .time {
     color: var(--body-color);
 }
 
-#chat .channel .highlight .toggle-content {
+#chat .chat-view[data-type=channel] .highlight .toggle-content {
     background-color: #6c7086;
 }
 


### PR DESCRIPTION
This PR includes 3 changes

1) I think the topic and server messages were too invisible (at least for macchiato) and it can look better (same color that channel topic)
    before
    ![image](https://github.com/user-attachments/assets/d1292b66-348c-4247-bfe5-2f7030b5dfa6)
    
    after
    ![image](https://github.com/user-attachments/assets/1aad1b3e-8269-48d7-95fb-247cec07a7c6)

2) The time selector (using `.channel`) seems wrong for highlight messages
    before
    ![image](https://github.com/user-attachments/assets/509d916d-4384-4e92-867e-57fe6f9e7175)
    
    after
    ![image](https://github.com/user-attachments/assets/8d117cab-aa5d-4ebb-bcf5-d2b7423daace)

3) The autocomplete drop-down was not applying the color
    before
    ![image](https://github.com/user-attachments/assets/a996ffce-59fc-481e-bf22-da0d153dbdc1)
    
    after
    ![image](https://github.com/user-attachments/assets/5d611194-e160-4c21-a3be-f2ab9af6919e)
